### PR TITLE
Build with latest security-minded stdio.h

### DIFF
--- a/src/clinet.c
+++ b/src/clinet.c
@@ -172,7 +172,7 @@ int dcc_connect_by_name(const char *host, int port, int *p_fd)
     rs_trace("connecting to %s port %d", host, port);
 
     /* Unfortunately for us, getaddrinfo wants the port (service) as a string */
-    snprintf(portname, sizeof portname, "%d", port);
+    snprintf_(portname, sizeof portname, "%d", port);
 
     memset(&hints, 0, sizeof(hints));
     /* set-up hints structure */

--- a/src/gcc-id.c
+++ b/src/gcc-id.c
@@ -97,7 +97,7 @@ char* dcc_make_dnssd_subtype(char *stype, size_t nbytes, const char *v, const ch
     strip_bad_chars(version);
     strip_bad_chars(machine);
 
-    snprintf(stype, nbytes, "_%s--%s._sub." DCC_DNS_SERVICE_TYPE, machine, version);
+    snprintf_(stype, nbytes, "_%s--%s._sub." DCC_DNS_SERVICE_TYPE, machine, version);
     stype[nbytes-1] = 0;
 
     return stype;

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -812,32 +812,27 @@ static void dopr_outch(char *buffer, size_t *currlen, size_t maxlen, char c)
     (*currlen)++;
 }
 
- int vsnprintf (char *str, size_t count, const char *fmt, va_list args)
+ int vsnprintf_ (char *str, size_t count, const char *fmt, va_list args)
 {
     return dopr(str, count, fmt, args);
 }
+#else
+ int vsnprintf_ (char *str, size_t count, const char *fmt, va_list args)
+{
+    return vsnprintf(str, count, fmt, args);
+}
 #endif
 
-/* yes this really must be a ||. Don't muck wiith this (tridge)
- *
- * The logic for these two is that we need our own definition if the
- * OS *either* has no definition of *sprintf, or if it does have one
- * that doesn't work properly according to the autoconf test.  Perhaps
- * these should really be smb_snprintf to avoid conflicts with buggy
- * linkers? -- mbp
- */
-#if !defined(HAVE_SNPRINTF) || !defined(HAVE_C99_VSNPRINTF)
- int snprintf(char *str,size_t count,const char *fmt,...)
+ int snprintf_(char *str,size_t count,const char *fmt,...)
 {
     size_t ret;
     va_list ap;
 
     va_start(ap, fmt);
-    ret = vsnprintf(str, count, fmt, ap);
+    ret = vsnprintf_(str, count, fmt, ap);
     va_end(ap);
     return ret;
 }
-#endif
 #endif /* HAVE_SNPRINTF, and everything */
 
 #ifndef HAVE_VASPRINTF
@@ -847,7 +842,7 @@ static void dopr_outch(char *buffer, size_t *currlen, size_t maxlen, char c)
     va_list ap2;
 
     VA_COPY(ap2, ap);
-    ret = vsnprintf(NULL, 0, format, ap2);
+    ret = vsnprintf_(NULL, 0, format, ap2);
     VA_COPY_END(ap2);
     if (ret <= 0) return ret;
 
@@ -855,7 +850,7 @@ static void dopr_outch(char *buffer, size_t *currlen, size_t maxlen, char c)
     if (!*ptr) return -1;
 
     VA_COPY(ap2, ap);
-    ret = vsnprintf(*ptr, ret+1, format, ap2);
+    ret = vsnprintf_(*ptr, ret+1, format, ap2);
     VA_COPY_END(ap2);
 
     return ret;
@@ -962,8 +957,8 @@ int checked_asprintf(char **ptr, const char *format, ...)
 
     for (x = 0; fp_fmt[x] ; x++) {
         for (y = 0; fp_nums[y] != 0 ; y++) {
-            int l1 = snprintf(NULL, 0, fp_fmt[x], fp_nums[y]);
-            int l2 = snprintf(buf1, sizeof(buf1), fp_fmt[x], fp_nums[y]);
+            int l1 = snprintf_(NULL, 0, fp_fmt[x], fp_nums[y]);
+            int l2 = snprintf_(buf1, sizeof(buf1), fp_fmt[x], fp_nums[y]);
             sprintf (buf2, fp_fmt[x], fp_nums[y]);
             if (strcmp (buf1, buf2)) {
                 printf("snprintf doesn't match Format: %s\n\tsnprintf = [%s]\n\t sprintf = [%s]\n",
@@ -980,8 +975,8 @@ int checked_asprintf(char **ptr, const char *format, ...)
 
     for (x = 0; int_fmt[x] ; x++) {
         for (y = 0; int_nums[y] != 0 ; y++) {
-            int l1 = snprintf(NULL, 0, int_fmt[x], int_nums[y]);
-            int l2 = snprintf(buf1, sizeof(buf1), int_fmt[x], int_nums[y]);
+            int l1 = snprintf_(NULL, 0, int_fmt[x], int_nums[y]);
+            int l2 = snprintf_(buf1, sizeof(buf1), int_fmt[x], int_nums[y]);
             sprintf (buf2, int_fmt[x], int_nums[y]);
             if (strcmp (buf1, buf2)) {
                 printf("snprintf doesn't match Format: %s\n\tsnprintf = [%s]\n\t sprintf = [%s]\n",
@@ -998,8 +993,8 @@ int checked_asprintf(char **ptr, const char *format, ...)
 
     for (x = 0; str_fmt[x] ; x++) {
         for (y = 0; str_vals[y] != 0 ; y++) {
-            int l1 = snprintf(NULL, 0, str_fmt[x], str_vals[y]);
-            int l2 = snprintf(buf1, sizeof(buf1), str_fmt[x], str_vals[y]);
+            int l1 = snprintf_(NULL, 0, str_fmt[x], str_vals[y]);
+            int l2 = snprintf_(buf1, sizeof(buf1), str_fmt[x], str_vals[y]);
             sprintf (buf2, str_fmt[x], str_vals[y]);
             if (strcmp (buf1, buf2)) {
                 printf("snprintf doesn't match Format: %s\n\tsnprintf = [%s]\n\t sprintf = [%s]\n",
@@ -1022,7 +1017,7 @@ int checked_asprintf(char **ptr, const char *format, ...)
         for (x=0; x<100; x++) {
             double p = pow(10, x);
             double r = v0*p;
-            snprintf(buf1, sizeof(buf1), "%1.1f", r);
+            snprintf_(buf1, sizeof(buf1), "%1.1f", r);
             sprintf(buf2,                "%1.1f", r);
             if (strcmp(buf1, buf2)) {
                 printf("we seem to support %d digits\n", x-1);

--- a/src/snprintf.h
+++ b/src/snprintf.h
@@ -27,15 +27,11 @@
 #if !HAVE_DECL_VASPRINTF
 int vasprintf(char **ptr, const char *format, va_list ap);
 #endif
-#if !HAVE_DECL_SNPRINTF
-int snprintf(char *,size_t ,const char *, ...) PRINTF_ATTRIBUTE(3,4);
-#endif
+int snprintf_(char *,size_t ,const char *, ...) PRINTF_ATTRIBUTE(3,4);
 #if !HAVE_DECL_ASPRINTF
 int asprintf(char **,const char *, ...) PRINTF_ATTRIBUTE(2,3);
 #endif
 
-#if !HAVE_DECL_VSNPRINTF
-int vsnprintf(char *, size_t, const char *, va_list);
-#endif
+int vsnprintf_(char *, size_t, const char *, va_list);
 
 int checked_asprintf(char **, const char *, ...) PRINTF_ATTRIBUTE(2,3);

--- a/src/srvnet.c
+++ b/src/srvnet.c
@@ -132,7 +132,7 @@ int dcc_socket_listen(int port, int *fd_out, const char *listen_addr)
     }
 
     /* getaddrinfo wants a string for the service name */
-    snprintf(portname, sizeof portname, "%d", port);
+    snprintf_(portname, sizeof portname, "%d", port);
 
     /* Set-up hints structure.  */
     memset(&hints, 0, sizeof(hints));

--- a/src/stats.c
+++ b/src/stats.c
@@ -46,6 +46,7 @@
 #include "netutil.h"
 #include "fcntl.h"
 #include "daemon.h"
+#include "snprintf.h"
 
 int dcc_statspipe[2];
 
@@ -416,7 +417,7 @@ dcc_free_space %d MB\n\
     if (dcc_check_client((struct sockaddr *)&cli_addr,
                          (int) cli_len,
                          opt_allowed) == 0) {
-        reply_len = snprintf(reply, 2048, replytemplate,
+        reply_len = snprintf_(reply, 2048, replytemplate,
                                dcc_stats.counters[STATS_TCP_ACCEPT],
                                dcc_stats.counters[STATS_REJ_BAD_REQ],
                                dcc_stats.counters[STATS_REJ_OVERLOAD],

--- a/src/zeroconf-reg.c
+++ b/src/zeroconf-reg.c
@@ -76,8 +76,8 @@ static void register_stuff(struct context *ctx) {
     if (avahi_entry_group_is_empty(ctx->group)) {
         char cpus[32], jobs[32], machine[64] = "cc_machine=", version[64] = "cc_version=", *m, *v;
 
-        snprintf(cpus, sizeof(cpus), "cpus=%i", ctx->n_cpus);
-        snprintf(jobs, sizeof(jobs), "jobs=%i", ctx->n_jobs);
+        snprintf_(cpus, sizeof(cpus), "cpus=%i", ctx->n_cpus);
+        snprintf_(jobs, sizeof(jobs), "jobs=%i", ctx->n_jobs);
         v = dcc_get_gcc_version(version+11, sizeof(version)-11);
         m = dcc_get_gcc_machine(machine+11, sizeof(machine)-11);
 

--- a/src/zeroconf.c
+++ b/src/zeroconf.c
@@ -164,9 +164,9 @@ static int write_hosts(struct daemon_data *d) {
             /* Not yet fully resolved */
             continue;
 	if (h->address.proto == AVAHI_PROTO_INET6)
-	    snprintf(t, sizeof(t), "[%s]:%u/%i\n", avahi_address_snprint(a, sizeof(a), &h->address), h->port, h->n_jobs);
+	    snprintf_(t, sizeof(t), "[%s]:%u/%i\n", avahi_address_snprint(a, sizeof(a), &h->address), h->port, h->n_jobs);
 	else
-	    snprintf(t, sizeof(t), "%s:%u/%i\n", avahi_address_snprint(a, sizeof(a), &h->address), h->port, h->n_jobs);
+	    snprintf_(t, sizeof(t), "%s:%u/%i\n", avahi_address_snprint(a, sizeof(a), &h->address), h->port, h->n_jobs);
 
         if (dcc_writex(d->fd, t, strlen(t)) != 0) {
             rs_log_crit("write() failed: %s\n", strerror(errno));


### PR DESCRIPTION
vsnprintf and snprintf are now macros, so we can't redefine them as functions
(and it wouldn't work anyway).  Instead, go through our own stubs, snprintf_ and
vsnprintf_.